### PR TITLE
chore: 添加 Cloud Agent 开发环境配置

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "FE-BLOG",
+  "install": "corepack pnpm install --frozen-lockfile",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "corepack pnpm run dev",
+      "description": "Next.js development server, serving the blog at http://localhost:3000"
+    }
+  ],
+  "ports": [
+    {
+      "name": "Next.js dev server",
+      "port": 3000
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

为本仓库添加 Cloud Agent 开发环境配置文件 `.cursor/environment.json`，使未来的 Cloud Agent 能够开箱即用地运行这个 Next.js 博客。

## 配置说明

- **基础镜像**：使用 Cursor 默认镜像即可（已内置 Node.js 22 + Corepack + pnpm），无需自定义 Dockerfile。
- **`install`**：`corepack pnpm install --frozen-lockfile` — 使用 `package.json` 中锁定的 pnpm 10.18.0 安装依赖，遵循 lockfile。
- **`terminals`**：运行 `corepack pnpm run dev` 启动 Next.js 开发服务器（`http://localhost:3000`）。
- **`ports`**：暴露 3000 端口。

## 验证

在当前 VM 上完成了端到端验证：

| 检查项 | 结果 |
| --- | --- |
| `corepack pnpm install --frozen-lockfile` | 成功 |
| 安装幂等性（二次运行） | 成功 |
| `pnpm run build`（含 sitemap 生成） | 成功，全部页面正常构建 |
| 开发服务器 `/`、`/blog`、`/blog/[...slug]`、`/tags`、`/projects` | 均返回 HTTP 200 并渲染真实内容 |
| 浏览器端到端浏览 | 首页、博客文章、标签页、项目页均正常渲染 |

## 备注

`pnpm run lint` 目前会失败，原因是 `eslint.config.mjs` 直接 `import '@eslint/js'`，但 `@eslint/js` 未在 `package.json` 中声明为直接依赖（仅存在于 pnpm store 中）。这是仓库自身的已有问题，与环境配置无关，本 PR 未做修改。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af6c407f-040f-4b51-b63e-5a84f1c97506?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af6c407f-040f-4b51-b63e-5a84f1c97506&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

